### PR TITLE
refactor(simplelog): lightweight hardening for One.SimpleLog

### DIFF
--- a/One.SimpleLog/LogManager.cs
+++ b/One.SimpleLog/LogManager.cs
@@ -5,19 +5,30 @@ namespace One.SimpleLog;
 
 public static class LogManager
 {
+    private static readonly object Locker = new();
+    private static LoggerWrapper? logger;
+
     /// <summary>
     /// 获得日志记录器
     /// </summary>
     public static LoggerWrapper GetLogger()
     {
-        switch (LogConfigHelper.GetTarget())
+        if (logger != null)
+            return logger;
+
+        lock (Locker)
         {
-            case "Console":
-                return new LoggerWrapper(new ConsoleLogger());
-            case "File":
-                return new LoggerWrapper(new FileLogger());
-            default:
-                return null;
+            if (logger != null)
+                return logger;
+
+            logger = LogConfigHelper.GetTarget() switch
+            {
+                "Console" => new LoggerWrapper(new ConsoleLogger()),
+                "File" => new LoggerWrapper(new FileLogger()),
+                _ => new LoggerWrapper(new NullLogger()),
+            };
+
+            return logger;
         }
     }
 }

--- a/One.SimpleLog/Loggers/FileLogger.cs
+++ b/One.SimpleLog/Loggers/FileLogger.cs
@@ -4,71 +4,69 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using One.SimpleLog.Configurations;
 using One.SimpleLog.Enum;
-using static System.Net.Mime.MediaTypeNames;
 
 namespace One.SimpleLog.Loggers;
 
 internal class FileLogger : BaseLogger
 {
     private readonly object _lock = new object();
-    string logPath;
 
     internal override void Log(string message, LogLevel level)
     {
-        logPath = LogConfigHelper.GetLogFile();
+        if (!IsWriteable(level))
+            return;
 
+        var logPath = ResolveLogPath();
+        var newMsg = ReplacePatternProperty(message);
+
+        lock (_lock)
+        {
+            CheckDirectory(logPath);
+            CheckRollBackups(logPath);
+            File.AppendAllText(logPath, newMsg);
+        }
+    }
+
+    private string ResolveLogPath()
+    {
+        var logPath = LogConfigHelper.GetLogFile();
         logPath = ReplacePredefinedProperty(logPath);
         logPath = ReplaceTargetProperty(logPath);
-
-        if (IsWriteable(level))
-        {
-            var newMsg = ReplacePatternProperty(message);
-            lock (_lock)
-            {
-                CheckRollBackups();
-                CheckDirectory(logPath);
-                File.AppendAllText(logPath, newMsg);
-            }
-        }
+        return logPath;
     }
 
     /// <summary>
     /// 检查是否需要滚动日志
     /// </summary>
-    private static void CheckRollBackups()
+    private static void CheckRollBackups(string logPath)
     {
         var maxRollTime = LogConfigHelper.GetMaxRollTime();
         var maxRollSize = LogConfigHelper.GetMaxRollSize();
-        var file = new FileInfo(LogConfigHelper.GetLogFile());
+        var file = new FileInfo(logPath);
         if (!file.Exists)
             return;
 
         var fileSizeInBytes = file.Length;
-        var timeDifference = DateTime.Now - file.CreationTime;
+        var timeDifference = DateTime.Now - file.LastWriteTime;
 
         if ((maxRollTime > 0 && timeDifference.TotalSeconds >= maxRollTime) || (maxRollSize > 0 && fileSizeInBytes >= maxRollSize))
-        {
-            RollBackups();
-        }
+            RollBackups(logPath);
     }
 
     /// <summary>
     /// 滚动日志
     /// </summary>
-    private static void RollBackups()
+    private static void RollBackups(string logPath)
     {
         var now = DateTime.Now;
         var strNow = $"{now:yyyy-MM-dd_HH-mm-ss}";
-        var logPath = LogConfigHelper.GetLogFile();
         var maxRollBackups = LogConfigHelper.GetMaxRollBackups();
         try
         {
             if (maxRollBackups > 0)
-                DeleteOldRollBackups(maxRollBackups);
+                DeleteOldRollBackups(logPath, maxRollBackups);
 
             File.Move(logPath, $"{logPath}.{strNow}");
-            File.Create(logPath).Close();
-            File.SetCreationTime(logPath, now);
         }
         catch (Exception ex)
         {
@@ -81,10 +79,8 @@ internal class FileLogger : BaseLogger
     /// 删除旧的滚动日志，保持最大滚动日志数量
     /// </summary>
     /// <param name="maxRollBackups">最大日志数量</param>
-    private static void DeleteOldRollBackups(int maxRollBackups)
+    private static void DeleteOldRollBackups(string logPath, int maxRollBackups)
     {
-        var logPath = LogConfigHelper.GetLogFile();
-
         var fileName = Path.GetFileName(logPath);
         if (string.IsNullOrWhiteSpace(fileName))
             throw new NullReferenceException($"GetFileName Error: logPath is {logPath}");
@@ -93,28 +89,23 @@ internal class FileLogger : BaseLogger
         if (string.IsNullOrWhiteSpace(fileDir))
             fileDir = Environment.CurrentDirectory;
 
-        // 过滤日志备份文件
-        var regexPattern = $@"^{Regex.Escape(fileName)}\..*";
-        var files = Directory.GetFiles(fileDir).Where(f => Regex.IsMatch(Path.GetFileName(f), regexPattern)).ToArray();
+        var regexPattern = $@"^{Regex.Escape(fileName)}\.\d{{4}}-\d{{2}}-\d{{2}}_\d{{2}}-\d{{2}}-\d{{2}}$";
+        var files = Directory.GetFiles(fileDir)
+            .Where(f => Regex.IsMatch(Path.GetFileName(f), regexPattern))
+            .OrderByDescending(Path.GetFileName)
+            .ToArray();
 
-        if (files == null)
+        if (files.Length < maxRollBackups)
             return;
 
-        if (files.Length >= maxRollBackups)
-        {
-            // 按创建时间排序
-            Array.Sort(files, (a, b) => File.GetCreationTime(a).CompareTo(File.GetCreationTime(b)));
-
-            for (int i = 0; i <= files.Length - maxRollBackups; i++)
-                File.Delete(files[i]);
-        }
+        for (int i = maxRollBackups - 1; i < files.Length; i++)
+            File.Delete(files[i]);
     }
 
     private static void CheckDirectory(string path)
     {
         var dir = Path.GetDirectoryName(path);
-        if (!string.IsNullOrWhiteSpace(dir))
-            if (!Directory.Exists(dir))
-                Directory.CreateDirectory(dir);
+        if (!string.IsNullOrWhiteSpace(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
     }
 }

--- a/One.SimpleLog/Loggers/LoggerWrapper.cs
+++ b/One.SimpleLog/Loggers/LoggerWrapper.cs
@@ -19,15 +19,18 @@ public class LoggerWrapper
         var pattern = LogConfigHelper.GetPattern();
 
         var newMessage = pattern
-            .Replace("%Date", DateTime.Now.ToString(LogConfigHelper.GetDateFormat())) // FormatException
+            .Replace("%Date", DateTime.Now.ToString(LogConfigHelper.GetDateFormat()))
+            .Replace("%date", DateTime.Now.ToString(LogConfigHelper.GetDateFormat()))
             .Replace("%Level", level.ToString().ToUpper())
+            .Replace("%level", level.ToString().ToUpper())
             .Replace("%Stack", $"{new StackTrace(true)}")
+            .Replace("%stack", $"{new StackTrace(true)}")
             .Replace("%Message", message)
-            .Replace("%Newline", Environment.NewLine);
+            .Replace("%message", message)
+            .Replace("%Newline", Environment.NewLine)
+            .Replace("%newline", Environment.NewLine);
 
-        //.Replace("%thread",$"{Thread.CurrentThread.Name ?? ""}:{Environment.CurrentManagedThreadId}") //线程没有名称就不打印
-
-        baseLogger?.Log(newMessage, level);
+        baseLogger.Log(newMessage, level);
     }
 
     internal void SetTargetProperty(string propertyName, string propertyValue)
@@ -45,9 +48,19 @@ public class LoggerWrapper
         Log(message, LogLevel.Debug);
     }
 
+    public void Debug(Exception exception, string? message = null)
+    {
+        Log(FormatExceptionMessage(exception, message), LogLevel.Debug);
+    }
+
     public void Info(string message)
     {
         Log(message, LogLevel.Info);
+    }
+
+    public void Info(Exception exception, string? message = null)
+    {
+        Log(FormatExceptionMessage(exception, message), LogLevel.Info);
     }
 
     public void Warn(string message)
@@ -55,13 +68,36 @@ public class LoggerWrapper
         Log(message, LogLevel.Warn);
     }
 
+    public void Warn(Exception exception, string? message = null)
+    {
+        Log(FormatExceptionMessage(exception, message), LogLevel.Warn);
+    }
+
     public void Error(string message)
     {
         Log(message, LogLevel.Error);
     }
 
+    public void Error(Exception exception, string? message = null)
+    {
+        Log(FormatExceptionMessage(exception, message), LogLevel.Error);
+    }
+
     public void Fatal(string message)
     {
         Log(message, LogLevel.Fatal);
+    }
+
+    public void Fatal(Exception exception, string? message = null)
+    {
+        Log(FormatExceptionMessage(exception, message), LogLevel.Fatal);
+    }
+
+    private static string FormatExceptionMessage(Exception exception, string? message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+            return exception.ToString();
+
+        return $"{message}{Environment.NewLine}{exception}";
     }
 }

--- a/One.SimpleLog/Loggers/NullLogger.cs
+++ b/One.SimpleLog/Loggers/NullLogger.cs
@@ -1,0 +1,10 @@
+﻿using One.SimpleLog.Enum;
+
+namespace One.SimpleLog.Loggers;
+
+internal sealed class NullLogger : BaseLogger
+{
+    internal override void Log(string message, LogLevel level)
+    {
+    }
+}

--- a/One.SimpleLog/README.md
+++ b/One.SimpleLog/README.md
@@ -1,13 +1,23 @@
 ﻿## Usage:
 
 ```csharp
-var logger = LogManager.GetLogger(typeof(YourClass));
+var logger = LogManager.GetLogger()
+    .WithPatternProperty("thread", $"{Thread.CurrentThread.Name ?? ""}:{Environment.CurrentManagedThreadId}");
 
 logger.Debug("Hello World");
 logger.Info("Hello World");
 logger.Warn("Hello World");
 logger.Error("Hello World");
 logger.Fatal("Hello World");
+
+try
+{
+    throw new InvalidOperationException("boom");
+}
+catch (Exception ex)
+{
+    logger.Error(ex, "Something failed");
+}
 ```
 
 ## Config
@@ -18,40 +28,32 @@ App.config
 <?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <logging>
-    <target value="file" file="log/Mojito.log" maxRollBackups="30" maxRollTime="1d" />
+    <target value="File" file="log/Mojito.log" maxRollBackups="30" maxRollTime="1d" />
     <level value="Info" />
-    <pattern value="%date [%thread] %level %logger - %message%newline" />
+    <pattern value="%date [%thread] %level - %message%newline" />
   </logging>
 </configuration>
 ```
 
-Print stack
-
-```xml
-<pattern value="%date [%thread] %level %logger - %message%newline %stack" />
-```
-
-
 ### Options
 
-`target`: // Logger target `Console` | `file` 
-- `file` // Log path
-- `maxRollBackups="10"` // The maximum retention is 10 copies  
-- `maxRollSize="512kb"` // The log is larger than or equal to 512kb, Supported units is `b`, `kb`, `mb`, `gb`  
-- `maxRollTime="1d"` // The log is rolled every 1 day, Supported units is `s`, `m`, `h`, `d`
+`target`: logger target `Console` | `File`
+- `file`: log path
+- `maxRollBackups="10"`: keep latest 10 rolled files
+- `maxRollSize="512kb"`: roll when file size >= 512kb, supports `b`, `kb`, `mb`, `gb`
+- `maxRollTime="1d"`: roll every 1 day, supports `s`, `m`, `h`, `d`
 
-`level`: // Log level
+`level`: log level
 - `Debug`
 - `Info`
 - `Warn`
 - `Error`
 - `Fatal`
 
-`pattern` // Log pattern
-- `%date` // Date time default format is `yyyy-MM-dd HH:mm:ss`
-- `%level` // Log level
-- `%thread` // Thread name and Thread ID
-- `%logger` // Caller class name
-- `%stack` // Stack Trace
-- `%message` // Your message
-- `%newline` // Environment.NewLine
+`pattern`: log pattern (supports lower/upper case placeholders)
+- `%date` / `%Date`
+- `%level` / `%Level`
+- `%stack` / `%Stack`
+- `%message` / `%Message`
+- `%newline` / `%Newline`
+- custom placeholders via `.WithPatternProperty(...)`, e.g. `%thread`


### PR DESCRIPTION
### Motivation
- Improve robustness and ergonomics while keeping the logger lightweight and dependency-free. 
- Provide safe defaults to avoid NREs and make exception logging and pattern usage more convenient (aligning with common logging library expectations). 

### Description
- Make `LogManager.GetLogger()` a thread-safe lazy singleton and return a `NullLogger` fallback instead of `null` when the configured target is unknown. 
- Add `NullLogger` (no-op) and extend `LoggerWrapper` to support both lower/upper-case pattern placeholders and overloads for logging `Exception` with an optional message, using `FormatExceptionMessage`. 
- Rework `FileLogger` to resolve the runtime log path once (`ResolveLogPath()`), check roll conditions using the resolved path and `LastWriteTime`, move the log to a timestamped backup, and deterministically clean up old backups using a timestamped filename regex and ordered deletion. 
- Update README to reflect the actual API (`LogManager.GetLogger()` usage, `.WithPatternProperty(...)`, exception overloads, and normalized config examples). 

### Testing
- Attempted to build the solution with `dotnet build Avalonia.One.sln -c Release`, but the `dotnet` CLI is not available in the environment (error: `bash: command not found: dotnet`). 
- Verified repository changes and committed the refactor with `git add` / `git commit` successfully, and inspected diffs to confirm the intended edits were applied.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae2658db288328ad321b8d50f28c2a)