### PR TITLE
fix: adapt MainView sidebar colors to light/dark themes

### DIFF
--- a/One.Toolbox/App.axaml
+++ b/One.Toolbox/App.axaml
@@ -23,6 +23,10 @@
     </Application.Styles>
     <Application.Resources>
         <ResourceDictionary>
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceInclude x:Key="Dark" Source="/Themes/Dark.axaml" />
+                <ResourceInclude x:Key="Light" Source="/Themes/Light.axaml" />
+            </ResourceDictionary.ThemeDictionaries>
             <ResourceDictionary.MergedDictionaries>
                 <!--<ResourceInclude Source="/Assets/Languages/zh-CN.axaml" />-->
                 <ResourceInclude Source="/Assets/AvaloniaUIGeometries.axaml" />

--- a/One.Toolbox/Themes/Brushes.axaml
+++ b/One.Toolbox/Themes/Brushes.axaml
@@ -22,4 +22,10 @@
 
     <SolidColorBrush x:Key="GridLinesBrush" Color="{DynamicResource GridLinesColor}" />
 
+    <SolidColorBrush x:Key="MainViewNavPaneBackgroundBrush" Color="{DynamicResource MainViewNavPaneBackgroundColor}" />
+    <SolidColorBrush x:Key="MainViewNavPaneBorderBrush" Color="{DynamicResource MainViewNavPaneBorderColor}" />
+    <SolidColorBrush x:Key="MainViewNavSelectedBackgroundBrush" Color="{DynamicResource MainViewNavSelectedBackgroundColor}" />
+    <SolidColorBrush x:Key="MainViewNavSelectedForegroundBrush" Color="{DynamicResource MainViewNavSelectedForegroundColor}" />
+    <SolidColorBrush x:Key="MainViewNavSelectedBorderBrush" Color="{DynamicResource MainViewNavSelectedBorderColor}" />
+
 </ResourceDictionary>

--- a/One.Toolbox/Themes/Dark.axaml
+++ b/One.Toolbox/Themes/Dark.axaml
@@ -20,4 +20,10 @@
     
     <Color x:Key="GridLinesColor">#333337</Color>
 
+    <Color x:Key="MainViewNavPaneBackgroundColor">#252528</Color>
+    <Color x:Key="MainViewNavPaneBorderColor">#3F3F3F</Color>
+    <Color x:Key="MainViewNavSelectedBackgroundColor">#2D3C4A</Color>
+    <Color x:Key="MainViewNavSelectedForegroundColor">#78B9FF</Color>
+    <Color x:Key="MainViewNavSelectedBorderColor">#78B9FF</Color>
+
 </ResourceDictionary>

--- a/One.Toolbox/Themes/Light.axaml
+++ b/One.Toolbox/Themes/Light.axaml
@@ -20,4 +20,10 @@
 
     <Color x:Key="GridLinesColor">#7EB4EA</Color>
 
+    <Color x:Key="MainViewNavPaneBackgroundColor">#F3F3F3</Color>
+    <Color x:Key="MainViewNavPaneBorderColor">#E0E0E0</Color>
+    <Color x:Key="MainViewNavSelectedBackgroundColor">#E5F3FF</Color>
+    <Color x:Key="MainViewNavSelectedForegroundColor">#0067C0</Color>
+    <Color x:Key="MainViewNavSelectedBorderColor">#0067C0</Color>
+
 </ResourceDictionary>

--- a/One.Toolbox/Views/MainView.axaml
+++ b/One.Toolbox/Views/MainView.axaml
@@ -8,7 +8,7 @@
              x:DataType="vmMain:MainViewVM">
 
     <Grid ColumnDefinitions="Auto,*">
-        <Border Width="{Binding PaneWidth}" Background="#F3F3F3" BorderBrush="#E0E0E0" BorderThickness="0,0,1,0">
+        <Border Width="{Binding PaneWidth}" Background="{DynamicResource MainViewNavPaneBackgroundBrush}" BorderBrush="{DynamicResource MainViewNavPaneBorderBrush}" BorderThickness="0,0,1,0">
 
             <DockPanel LastChildFill="True">
                 <Button Width="46" Margin="2" HorizontalAlignment="Left" Background="Transparent"
@@ -30,9 +30,9 @@
                         </Style>
 
                         <Style Selector="ListBoxItem:selected /template/ ContentPresenter">
-                            <Setter Property="Background" Value="#E5F3FF" />
-                            <Setter Property="TextBlock.Foreground" Value="#0067C0" />
-                            <Setter Property="BorderBrush" Value="#0067C0" />
+                            <Setter Property="Background" Value="{DynamicResource MainViewNavSelectedBackgroundBrush}" />
+                            <Setter Property="TextBlock.Foreground" Value="{DynamicResource MainViewNavSelectedForegroundBrush}" />
+                            <Setter Property="BorderBrush" Value="{DynamicResource MainViewNavSelectedBorderBrush}" />
                             <Setter Property="BorderThickness" Value="1,0,0,0" />
                         </Style>
                     </ListBox.Styles>


### PR DESCRIPTION
### Motivation
- `MainView` used hard-coded colors for the left sidebar which did not follow the app `RequestedThemeVariant` and therefore did not adapt to Light/Dark themes.
- Move sidebar colors into theme resource dictionaries so the sidebar follows the selected theme and `SetTheme` behavior.

### Description
- Replaced hard-coded sidebar colors in `One.Toolbox/Views/MainView.axaml` with dynamic resources: `MainViewNavPaneBackgroundBrush`, `MainViewNavPaneBorderBrush`, `MainViewNavSelectedBackgroundBrush`, `MainViewNavSelectedForegroundBrush`, and `MainViewNavSelectedBorderBrush`.
- Added color keys for those resources in `One.Toolbox/Themes/Light.axaml` and `One.Toolbox/Themes/Dark.axaml` (`MainViewNav*Color` keys) to define Light/Dark variants.
- Added corresponding brush resources in `One.Toolbox/Themes/Brushes.axaml` that map the color keys to `SolidColorBrush` entries used by the view.
- Wired `One.Toolbox/App.axaml` to include the theme dictionaries via `ResourceDictionary.ThemeDictionaries` so `RequestedThemeVariant` will select the appropriate theme resources.

### Testing
- Attempted to build the `One.Toolbox` project with `dotnet build One.Toolbox/One.Toolbox.csproj`, but the environment lacks `dotnet` so the build could not be executed (failed).
- Attempted an automated Playwright page screenshot to visually validate UI, but the target web service was not reachable so the screenshot run failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae660d0694832883e552ab83139efa)