### PR TITLE
feat(toolbox): add PortTool module (port usage / TCP-UDP tests / socket debugger)

### DIFF
--- a/One.Toolbox/App.axaml.cs
+++ b/One.Toolbox/App.axaml.cs
@@ -14,6 +14,7 @@ using One.Toolbox.ViewModels.DataProcess;
 using One.Toolbox.ViewModels.HashTool;
 using One.Toolbox.ViewModels.IconBoard;
 using One.Toolbox.ViewModels.MainWindow;
+using One.Toolbox.ViewModels.PortTool;
 using One.Toolbox.ViewModels.QRCode;
 using One.Toolbox.ViewModels.RegularTester;
 using One.Toolbox.ViewModels.Serialport;
@@ -89,6 +90,7 @@ public partial class App : Application
         services.AddSingleton<RegularTesterPageVM>();
  
         services.AddSingleton<SerialportPageVM>();
+        services.AddSingleton<PortToolPageVM>();
 
         return services.BuildServiceProvider();
     }

--- a/One.Toolbox/ViewModels/MainWindow/MainViewVM.cs
+++ b/One.Toolbox/ViewModels/MainWindow/MainViewVM.cs
@@ -9,6 +9,7 @@ using One.Toolbox.ViewModels.Dashboard;
 using One.Toolbox.ViewModels.DataProcess;
 using One.Toolbox.ViewModels.HashTool;
 using One.Toolbox.ViewModels.Note;
+using One.Toolbox.ViewModels.PortTool;
 using One.Toolbox.ViewModels.QRCode;
 using One.Toolbox.ViewModels.RegularTester;
 using One.Toolbox.ViewModels.Serialport;
@@ -90,6 +91,12 @@ public partial class MainViewVM : BaseVM
                 Header = "Serialport",
                 Icon = ResourceHelper.FindObjectResource("SerialPort24Filled"),
                 Content = new SerialportPage() { DataContext = App.Current!.Services.GetService<SerialportPageVM>() },
+            },
+            new()
+            {
+                Header = "PortTool",
+                Icon = ResourceHelper.FindObjectResource("preview_link_regular"),
+                Content = new PortToolPage() { DataContext = App.Current!.Services.GetService<PortToolPageVM>() },
             },
             new()
             {

--- a/One.Toolbox/ViewModels/PortTool/PortToolPageVM.cs
+++ b/One.Toolbox/ViewModels/PortTool/PortToolPageVM.cs
@@ -1,0 +1,316 @@
+﻿using Avalonia.Controls;
+using Avalonia.Threading;
+
+using AvaloniaEdit.Document;
+
+using One.Base.Helpers.DataProcessHelpers;
+using One.Base.Helpers.NetHelpers;
+using One.Toolbox.ViewModels.Base;
+
+using System.Collections.ObjectModel;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using System.Text;
+
+namespace One.Toolbox.ViewModels.PortTool;
+
+public partial class PortToolPageVM : BasePageVM
+{
+    private AsyncTCPClient? tcpClient;
+    private AsyncTCPServer? tcpServer;
+    private AsyncUDPClient? udpClient;
+
+    [ObservableProperty]
+    private ObservableCollection<PortUsageItemVM> portUsageItems = [];
+
+    [ObservableProperty]
+    private string targetHost = "127.0.0.1";
+
+    [ObservableProperty]
+    private int targetPort = 80;
+
+    [ObservableProperty]
+    private int localPort = 9000;
+
+    [ObservableProperty]
+    private string testResult = "";
+
+    [ObservableProperty]
+    private bool socketHexSend;
+
+    [ObservableProperty]
+    private bool socketHexShow;
+
+    [ObservableProperty]
+    private string socketSendText = "";
+
+    [ObservableProperty]
+    private string socketRemoteHost = "127.0.0.1";
+
+    [ObservableProperty]
+    private int socketRemotePort = 9000;
+
+    [ObservableProperty]
+    private bool socketStarted;
+
+    [ObservableProperty]
+    private string socketMode = "TCP Client";
+
+    public ObservableCollection<string> SocketModes { get; } = ["TCP Client", "TCP Server", "UDP"];
+
+    [ObservableProperty]
+    private TextDocument logDocument = new();
+
+    public override void UpdateTitle()
+    {
+        Title = "端口工具";
+    }
+
+    [RelayCommand]
+    private void RefreshPortUsage()
+    {
+        var usages = new List<PortUsageItemVM>();
+        var ip = IPGlobalProperties.GetIPGlobalProperties();
+
+        foreach (var item in ip.GetActiveTcpListeners())
+        {
+            usages.Add(new PortUsageItemVM("TCP Listener", item.Address.ToString(), item.Port, "Listening"));
+        }
+
+        foreach (var item in ip.GetActiveUdpListeners())
+        {
+            usages.Add(new PortUsageItemVM("UDP Listener", item.Address.ToString(), item.Port, "Listening"));
+        }
+
+        foreach (var item in ip.GetActiveTcpConnections())
+        {
+            usages.Add(new PortUsageItemVM(
+                "TCP Connection",
+                item.LocalEndPoint.ToString(),
+                item.LocalEndPoint.Port,
+                item.State.ToString()));
+        }
+
+        PortUsageItems = new ObservableCollection<PortUsageItemVM>(usages.OrderBy(x => x.Port).ThenBy(x => x.Type));
+    }
+
+    [RelayCommand]
+    private async Task RunTcpTest()
+    {
+        try
+        {
+            using var client = new TcpClient();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+
+            await client.ConnectAsync(TargetHost, TargetPort, cts.Token);
+            TestResult = $"TCP连接成功: {TargetHost}:{TargetPort}";
+        }
+        catch (Exception ex)
+        {
+            TestResult = $"TCP连接失败: {ex.Message}";
+        }
+    }
+
+    [RelayCommand]
+    private async Task RunUdpTest()
+    {
+        try
+        {
+            using var client = new UdpClient(LocalPort);
+            var endpoint = new IPEndPoint(IPAddress.Parse(TargetHost), TargetPort);
+            var bytes = Encoding.UTF8.GetBytes("UDP TEST");
+            await client.SendAsync(bytes, endpoint);
+            TestResult = $"UDP发送成功: {endpoint}";
+        }
+        catch (Exception ex)
+        {
+            TestResult = $"UDP测试失败: {ex.Message}";
+        }
+    }
+
+    [RelayCommand]
+    private void StartSocket()
+    {
+        if (SocketStarted)
+            return;
+
+        try
+        {
+            switch (SocketMode)
+            {
+                case "TCP Client":
+                    StartTcpClient();
+                    break;
+
+                case "TCP Server":
+                    StartTcpServer();
+                    break;
+
+                case "UDP":
+                    StartUdp();
+                    break;
+            }
+
+            SocketStarted = true;
+            AppendLog($"Socket已启动: {SocketMode}");
+        }
+        catch (Exception ex)
+        {
+            AppendLog($"启动失败: {ex.Message}");
+        }
+    }
+
+    [RelayCommand]
+    private void StopSocket()
+    {
+        try
+        {
+            tcpClient?.ReleaseClient();
+            tcpServer?.ReleaseServer();
+            udpClient?.ReleaseClient();
+        }
+        catch (Exception ex)
+        {
+            AppendLog($"停止异常: {ex.Message}");
+        }
+        finally
+        {
+            tcpClient = null;
+            tcpServer = null;
+            udpClient = null;
+            SocketStarted = false;
+            AppendLog("Socket已停止");
+        }
+    }
+
+    [RelayCommand]
+    private void SendSocketData()
+    {
+        if (!SocketStarted)
+        {
+            AppendLog("请先启动Socket");
+            return;
+        }
+
+        try
+        {
+            var payload = BuildPayload(SocketSendText, SocketHexSend);
+            switch (SocketMode)
+            {
+                case "TCP Client":
+                    tcpClient?.SendData(payload);
+                    break;
+
+                case "TCP Server":
+                    tcpServer?.SendDataToAll(payload);
+                    break;
+
+                case "UDP":
+                    udpClient?.SendData(new IPEndPoint(IPAddress.Parse(SocketRemoteHost), SocketRemotePort), payload);
+                    break;
+            }
+
+            AppendLog($"[Send] {FormatBytes(payload, SocketHexSend)}");
+        }
+        catch (Exception ex)
+        {
+            AppendLog($"发送失败: {ex.Message}");
+        }
+    }
+
+    [RelayCommand]
+    private void ClearLog()
+    {
+        LogDocument = new TextDocument();
+    }
+
+    public override void OnNavigatedEnter(UserControl userControl)
+    {
+        base.OnNavigatedEnter(userControl);
+        RefreshPortUsage();
+    }
+
+    private void StartTcpClient()
+    {
+        tcpClient = new AsyncTCPClient(WriteInfoLog);
+        tcpClient.ReceiveAction = data => AppendLog($"[Recv] {FormatBytes(data, SocketHexShow)}");
+        tcpClient.OnConnected = data => AppendLog($"[Conn] {Encoding.UTF8.GetString(data)}");
+        tcpClient.OnDisConnected = data => AppendLog($"[Disc] {Encoding.UTF8.GetString(data)}");
+
+        if (!tcpClient.InitClient(IPAddress.Parse(SocketRemoteHost), SocketRemotePort))
+        {
+            throw new Exception("TCP客户端启动失败");
+        }
+    }
+
+    private void StartTcpServer()
+    {
+        tcpServer = new AsyncTCPServer(WriteInfoLog);
+        tcpServer.ReceiveAction = (_, data) => AppendLog($"[Recv] {FormatBytes(data, SocketHexShow)}");
+        tcpServer.OnConnected = data => AppendLog($"[Conn] {Encoding.UTF8.GetString(data)}");
+        tcpServer.OnDisConnected = data => AppendLog($"[Disc] {Encoding.UTF8.GetString(data)}");
+
+        if (!tcpServer.InitAsServer(IPAddress.Any, LocalPort))
+        {
+            throw new Exception("TCP服务端启动失败");
+        }
+    }
+
+    private void StartUdp()
+    {
+        udpClient = new AsyncUDPClient(WriteInfoLog);
+        udpClient.ReceiveAction = (remote, data) => AppendLog($"[Recv {remote}] {FormatBytes(data, SocketHexShow)}");
+        udpClient.OnConnected = data => AppendLog($"[Conn] {Encoding.UTF8.GetString(data)}");
+        udpClient.OnDisConnected = _ => AppendLog("[Disc] UDP Closed");
+
+        if (!udpClient.InitClient(IPAddress.Any, LocalPort))
+        {
+            throw new Exception("UDP启动失败");
+        }
+    }
+
+    private byte[] BuildPayload(string text, bool hex)
+    {
+        if (!hex)
+        {
+            return Encoding.UTF8.GetBytes(text ?? string.Empty);
+        }
+
+        return StringHelper.HexStringToBytes((text ?? string.Empty).Replace(" ", ""));
+    }
+
+    private string FormatBytes(byte[] data, bool hex)
+    {
+        if (hex)
+        {
+            return StringHelper.BytesToHexString(data);
+        }
+
+        return Encoding.UTF8.GetString(data);
+    }
+
+    private void AppendLog(string line)
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            LogDocument.Insert(LogDocument.TextLength, $"{DateTime.Now:HH:mm:ss.fff} {line}{Environment.NewLine}");
+        });
+    }
+}
+
+public partial class PortUsageItemVM : ObservableObject
+{
+    public PortUsageItemVM(string type, string endpoint, int port, string state)
+    {
+        Type = type;
+        Endpoint = endpoint;
+        Port = port;
+        State = state;
+    }
+
+    public string Type { get; }
+    public string Endpoint { get; }
+    public int Port { get; }
+    public string State { get; }
+}

--- a/One.Toolbox/Views/PortTool/PortToolPage.axaml
+++ b/One.Toolbox/Views/PortTool/PortToolPage.axaml
@@ -1,0 +1,75 @@
+<UserControl x:Class="One.Toolbox.Views.PortToolPage"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:AvaloniaEdit="clr-namespace:AvaloniaEdit;assembly=AvaloniaEdit"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="using:One.Toolbox.ViewModels.PortTool"
+             d:DesignHeight="450"
+             d:DesignWidth="900"
+             x:DataType="vm:PortToolPageVM"
+             mc:Ignorable="d">
+    <TabControl Margin="8">
+        <TabItem Header="端口占用">
+            <Grid RowDefinitions="Auto,*" RowSpacing="8">
+                <Button HorizontalAlignment="Left" Command="{Binding RefreshPortUsageCommand}" Content="刷新端口占用" />
+                <DataGrid Grid.Row="1" AutoGenerateColumns="False" IsReadOnly="True" ItemsSource="{Binding PortUsageItems}">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Binding="{Binding Type}" Header="类型" Width="150" />
+                        <DataGridTextColumn Binding="{Binding Endpoint}" Header="端点" Width="*" />
+                        <DataGridTextColumn Binding="{Binding Port}" Header="端口" Width="100" />
+                        <DataGridTextColumn Binding="{Binding State}" Header="状态" Width="120" />
+                    </DataGrid.Columns>
+                </DataGrid>
+            </Grid>
+        </TabItem>
+
+        <TabItem Header="TCP/UDP测试">
+            <StackPanel Spacing="8">
+                <Grid ColumnDefinitions="Auto,160,Auto,100,Auto,100,*" ColumnSpacing="8">
+                    <TextBlock VerticalAlignment="Center" Text="目标IP" />
+                    <TextBox Grid.Column="1" Text="{Binding TargetHost}" />
+                    <TextBlock Grid.Column="2" VerticalAlignment="Center" Text="目标端口" />
+                    <TextBox Grid.Column="3" Text="{Binding TargetPort}" />
+                    <TextBlock Grid.Column="4" VerticalAlignment="Center" Text="本地端口" />
+                    <TextBox Grid.Column="5" Text="{Binding LocalPort}" />
+                </Grid>
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <Button Command="{Binding RunTcpTestCommand}" Content="TCP连接测试" />
+                    <Button Command="{Binding RunUdpTestCommand}" Content="UDP发送测试" />
+                </StackPanel>
+                <TextBlock Foreground="DarkCyan" Text="{Binding TestResult}" TextWrapping="Wrap" />
+            </StackPanel>
+        </TabItem>
+
+        <TabItem Header="Socket调试">
+            <Grid RowDefinitions="Auto,Auto,*,Auto" RowSpacing="8">
+                <Grid ColumnDefinitions="Auto,130,Auto,160,Auto,100,Auto,100,*" ColumnSpacing="8">
+                    <TextBlock VerticalAlignment="Center" Text="模式" />
+                    <ComboBox Grid.Column="1" ItemsSource="{Binding SocketModes}" SelectedItem="{Binding SocketMode}" />
+                    <TextBlock Grid.Column="2" VerticalAlignment="Center" Text="远端IP" />
+                    <TextBox Grid.Column="3" Text="{Binding SocketRemoteHost}" />
+                    <TextBlock Grid.Column="4" VerticalAlignment="Center" Text="远端端口" />
+                    <TextBox Grid.Column="5" Text="{Binding SocketRemotePort}" />
+                    <TextBlock Grid.Column="6" VerticalAlignment="Center" Text="本地端口" />
+                    <TextBox Grid.Column="7" Text="{Binding LocalPort}" />
+                </Grid>
+
+                <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="8">
+                    <Button Command="{Binding StartSocketCommand}" Content="启动" IsEnabled="{Binding !SocketStarted}" />
+                    <Button Command="{Binding StopSocketCommand}" Content="停止" IsEnabled="{Binding SocketStarted}" />
+                    <CheckBox Content="Hex发送" IsChecked="{Binding SocketHexSend}" />
+                    <CheckBox Content="Hex显示" IsChecked="{Binding SocketHexShow}" />
+                    <Button Command="{Binding ClearLogCommand}" Content="清空日志" />
+                </StackPanel>
+
+                <AvaloniaEdit:TextEditor Grid.Row="2" Document="{Binding LogDocument}" FontFamily="Cascadia Code,Consolas,Menlo,Monospace" ShowLineNumbers="True" />
+
+                <Grid Grid.Row="3" ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                    <TextBox AcceptsReturn="True" MinHeight="60" Text="{Binding SocketSendText}" TextWrapping="Wrap" />
+                    <Button Grid.Column="1" MinWidth="90" Command="{Binding SendSocketDataCommand}" Content="发送" />
+                </Grid>
+            </Grid>
+        </TabItem>
+    </TabControl>
+</UserControl>

--- a/One.Toolbox/Views/PortTool/PortToolPage.axaml.cs
+++ b/One.Toolbox/Views/PortTool/PortToolPage.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace One.Toolbox.Views;
+
+public partial class PortToolPage : UserControl
+{
+    public PortToolPage()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a network-oriented counterpart to the existing serial-port debug tool to inspect port usage and perform TCP/UDP/socket debugging. 
- Reuse existing network helper classes under `One.Base.Helpers.NetHelpers` to implement socket client/server/udp flows.

### Description
- Add a new `PortTool` page and ViewModel: `One.Toolbox/ViewModels/PortTool/PortToolPageVM.cs` and `One.Toolbox/Views/PortTool/PortToolPage.axaml` (with code-behind `PortToolPage.axaml.cs`).
- Implement features: port usage listing (TCP/UDP listeners and TCP connections), TCP connection test, UDP send test, and a Socket debugger supporting `TCP Client`, `TCP Server`, and `UDP` modes with start/stop, send, Hex send/display and log output (uses `AsyncTCPClient`, `AsyncTCPServer`, `AsyncUDPClient`).
- Integrate the module into the app: register `PortToolPageVM` in DI (`One.Toolbox/App.axaml.cs`) and add a `PortTool` entry to the main navigation (`One.Toolbox/ViewModels/MainWindow/MainViewVM.cs`).
- Utilities provided: payload builder (`Hex`/text), byte formatting for log display, log append helper, and a `PortUsageItemVM` to present port information.

### Testing
- Ran repository checks with `git diff --check` which reported no problems.
- Attempted to run `dotnet build Avalonia.One.sln` but the environment lacks the `dotnet` SDK so a full compile was not performed and build validation could not be completed. 
- Verified added source files are present and navigation/DI registrations were updated; view/viewmodel bindings are implemented following the existing serialport page pattern.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21114c9f4832894e4de004959a898)