### PR TITLE
优化网络调试工具 UI 与 Socket 日志，增强 NetHelpers 稳定性

### DIFF
--- a/One.Base/Helpers/NetHelpers/AsyncTCPClient.cs
+++ b/One.Base/Helpers/NetHelpers/AsyncTCPClient.cs
@@ -15,7 +15,7 @@ public class AsyncTCPClient : BaseHelper
 {
     #region 变量
 
-    private Socket socket = null;
+    private Socket? socket;
 
     #endregion 变量
 
@@ -77,11 +77,13 @@ public class AsyncTCPClient : BaseHelper
         try
         {
             //客户端自己的Socket,也可以直接用最开始的socket
-            var localClientSocket = e.ConnectSocket;//连接的 Socket 对象。
-            var addressFamily = localClientSocket.AddressFamily.ToString();
+            if (e.SocketError != SocketError.Success || e.ConnectSocket == null)
+            {
+                throw new SocketException((int)e.SocketError);
+            }
 
-            // var a = localClientSocket.LocalEndPoint.ToString();
-            var a = $"{localClientSocket.LocalEndPoint.ToString()} connected!";
+            var localClientSocket = e.ConnectSocket;//连接的 Socket 对象。
+            var a = $"{localClientSocket.LocalEndPoint} connected!";
 
             var info = System.Text.Encoding.UTF8.GetBytes(a);
             OnConnected?.Invoke(info);
@@ -105,18 +107,27 @@ public class AsyncTCPClient : BaseHelper
     {
         try
         {
-            socket.Shutdown(SocketShutdown.Both);
+            if (socket == null)
+            {
+                return;
+            }
+
+            if (socket.Connected)
+            {
+                socket.Shutdown(SocketShutdown.Both);
+            }
 
             var a = $"{socket.LocalEndPoint} disconnected!";
             var info = System.Text.Encoding.UTF8.GetBytes(a);
             OnDisConnected?.Invoke(info);
 
             socket.Close();
+            socket = null;
         }
         catch (Exception ex)
         {
             WriteLog(ex.ToString());
-            throw ex;
+            // ignore close exception
         }
     }
 
@@ -130,6 +141,11 @@ public class AsyncTCPClient : BaseHelper
             int bytesSent = 0;
             while (bytesSent < data.Length)
             {
+                if (socket == null)
+                {
+                    return;
+                }
+
                 bytesSent += await socket.SendAsync(data.AsMemory(bytesSent), SocketFlags.None);
             }
 
@@ -148,17 +164,19 @@ public class AsyncTCPClient : BaseHelper
         {
             while (true)
             {
-                if (!socket.Connected)
+                if (socket == null || !socket.Connected)
                 {
                     return;
                 }
                 byte[] responseBytes = new byte[1024];
                 int bytesReceived = await socket.ReceiveAsync(responseBytes, SocketFlags.None, cancellationToken);
 
-                if (bytesReceived > 0)
+                if (bytesReceived <= 0)
                 {
-                    ReceiveAction?.Invoke(responseBytes.Take(bytesReceived).ToArray());
+                    return;
                 }
+
+                ReceiveAction?.Invoke(responseBytes.Take(bytesReceived).ToArray());
             }
         }
         catch (Exception ex)

--- a/One.Base/Helpers/NetHelpers/AsyncTCPServer.cs
+++ b/One.Base/Helpers/NetHelpers/AsyncTCPServer.cs
@@ -59,7 +59,7 @@ public class AsyncTCPServer : BaseHelper
         catch (Exception ex)
         {
             WriteLog(ex.ToString());
-            throw ex;
+            throw;
         }
     }
 
@@ -67,7 +67,26 @@ public class AsyncTCPServer : BaseHelper
     {
         try
         {
-            sckServer.Shutdown(SocketShutdown.Both);
+            foreach (var client in listConnection.ToList())
+            {
+                try
+                {
+                    if (client.Connected)
+                    {
+                        client.Shutdown(SocketShutdown.Both);
+                    }
+
+                    var info = System.Text.Encoding.UTF8.GetBytes($"{client.RemoteEndPoint} disconnected!");
+                    OnDisConnected?.Invoke(info);
+                    client.Close();
+                }
+                catch
+                {
+                }
+            }
+            listConnection.Clear();
+
+            sckServer?.Shutdown(SocketShutdown.Both);
         }
         catch (Exception ex)
         {
@@ -76,7 +95,7 @@ public class AsyncTCPServer : BaseHelper
         }
         try
         {
-            sckServer.Close();
+            sckServer?.Close();
         }
         catch (Exception ex)
         {

--- a/One.Base/Helpers/NetHelpers/AsyncUDPClient.cs
+++ b/One.Base/Helpers/NetHelpers/AsyncUDPClient.cs
@@ -14,7 +14,7 @@ public class AsyncUDPClient : BaseHelper
 {
     #region 变量
 
-    protected UdpClient udpClient = null;
+    protected UdpClient? udpClient;
 
     #endregion 变量
 
@@ -69,12 +69,17 @@ public class AsyncUDPClient : BaseHelper
         try
         {
             //注意对于udp协议来说，仍然接受并排列传入的数据，因此udp套接字而言shutdown毫无意义
+            if (udpClient == null)
+            {
+                return;
+            }
+
+            var localEndPoint = udpClient.Client.LocalEndPoint?.ToString() ?? "UDP";
             udpClient.Close();
+            udpClient = null;
 
-            var info = System.Text.Encoding.UTF8.GetBytes("DD");
+            var info = System.Text.Encoding.UTF8.GetBytes($"{localEndPoint} closed");
             OnDisConnected?.Invoke(info);
-
-            cancellationToken.ThrowIfCancellationRequested();
         }
         catch (Exception ex)
         {
@@ -89,12 +94,12 @@ public class AsyncUDPClient : BaseHelper
             // int count = sckClient.Send(data);
             //Console.WriteLine("发送数据长度为：" + count);
 
-            int bytesSent = 0;
-            while (bytesSent < data.Length)
+            if (udpClient == null)
             {
-                bytesSent += await udpClient.SendAsync(data.AsMemory(bytesSent), iPEndPoint);
+                return;
             }
 
+            await udpClient.SendAsync(data, iPEndPoint);
             SendAction?.Invoke(data);
         }
         catch (Exception ex)
@@ -110,6 +115,11 @@ public class AsyncUDPClient : BaseHelper
         {
             while (true)
             {
+                if (udpClient == null)
+                {
+                    return;
+                }
+
                 var receive = await udpClient.ReceiveAsync(cancellationToken);
 
                 if (receive.Buffer.Length > 0)

--- a/One.Toolbox/ViewModels/NetTool/NetToolPageVM.cs
+++ b/One.Toolbox/ViewModels/NetTool/NetToolPageVM.cs
@@ -10,7 +10,6 @@ using One.Toolbox.ViewModels.Base;
 using System.Collections.ObjectModel;
 using System.Net;
 using System.Net.NetworkInformation;
-using System.Net.Sockets;
 using System.Text;
 
 namespace One.Toolbox.ViewModels.NetTool;
@@ -25,16 +24,7 @@ public partial class NetToolPageVM : BasePageVM
     private ObservableCollection<PortUsageItemVM> portUsageItems = [];
 
     [ObservableProperty]
-    private string targetHost = "127.0.0.1";
-
-    [ObservableProperty]
-    private int targetPort = 80;
-
-    [ObservableProperty]
     private int localPort = 9000;
-
-    [ObservableProperty]
-    private string testResult = "";
 
     [ObservableProperty]
     private bool socketHexSend;
@@ -61,6 +51,16 @@ public partial class NetToolPageVM : BasePageVM
 
     [ObservableProperty]
     private TextDocument logDocument = new();
+
+    public bool IsTcpClientMode => SocketMode == "TCP Client";
+
+    public bool IsTcpServerMode => SocketMode == "TCP Server";
+
+    public bool IsUdpMode => SocketMode == "UDP";
+
+    public bool ShowRemoteEndpoint => IsTcpClientMode || IsUdpMode;
+
+    public bool ShowLocalPort => IsTcpServerMode || IsUdpMode;
 
     public override void UpdateTitle()
     {
@@ -96,40 +96,6 @@ public partial class NetToolPageVM : BasePageVM
     }
 
     [RelayCommand]
-    private async Task RunTcpTest()
-    {
-        try
-        {
-            using var client = new TcpClient();
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
-
-            await client.ConnectAsync(TargetHost, TargetPort, cts.Token);
-            TestResult = $"TCP连接成功: {TargetHost}:{TargetPort}";
-        }
-        catch (Exception ex)
-        {
-            TestResult = $"TCP连接失败: {ex.Message}";
-        }
-    }
-
-    [RelayCommand]
-    private async Task RunUdpTest()
-    {
-        try
-        {
-            using var client = new UdpClient(LocalPort);
-            var endpoint = new IPEndPoint(IPAddress.Parse(TargetHost), TargetPort);
-            var bytes = Encoding.UTF8.GetBytes("UDP TEST");
-            await client.SendAsync(bytes, endpoint);
-            TestResult = $"UDP发送成功: {endpoint}";
-        }
-        catch (Exception ex)
-        {
-            TestResult = $"UDP测试失败: {ex.Message}";
-        }
-    }
-
-    [RelayCommand]
     private void StartSocket()
     {
         if (SocketStarted)
@@ -153,11 +119,11 @@ public partial class NetToolPageVM : BasePageVM
             }
 
             SocketStarted = true;
-            AppendLog($"Socket已启动: {SocketMode}");
+            AppendLog($"[SYS] Socket已启动: {SocketMode}");
         }
         catch (Exception ex)
         {
-            AppendLog($"启动失败: {ex.Message}");
+            AppendLog($"[ERR] 启动失败: {ex.Message}");
         }
     }
 
@@ -172,7 +138,7 @@ public partial class NetToolPageVM : BasePageVM
         }
         catch (Exception ex)
         {
-            AppendLog($"停止异常: {ex.Message}");
+            AppendLog($"[ERR] 停止异常: {ex.Message}");
         }
         finally
         {
@@ -180,7 +146,7 @@ public partial class NetToolPageVM : BasePageVM
             tcpServer = null;
             udpClient = null;
             SocketStarted = false;
-            AppendLog("Socket已停止");
+            AppendLog("[SYS] Socket已停止");
         }
     }
 
@@ -189,7 +155,7 @@ public partial class NetToolPageVM : BasePageVM
     {
         if (!SocketStarted)
         {
-            AppendLog("请先启动Socket");
+            AppendLog("[SYS] 请先启动Socket");
             return;
         }
 
@@ -211,11 +177,10 @@ public partial class NetToolPageVM : BasePageVM
                     break;
             }
 
-            AppendLog($"[Send] {FormatBytes(payload, SocketHexSend)}");
         }
         catch (Exception ex)
         {
-            AppendLog($"发送失败: {ex.Message}");
+            AppendLog($"[ERR] 发送失败: {ex.Message}");
         }
     }
 
@@ -231,12 +196,22 @@ public partial class NetToolPageVM : BasePageVM
         RefreshPortUsage();
     }
 
+    partial void OnSocketModeChanged(string value)
+    {
+        OnPropertyChanged(nameof(IsTcpClientMode));
+        OnPropertyChanged(nameof(IsTcpServerMode));
+        OnPropertyChanged(nameof(IsUdpMode));
+        OnPropertyChanged(nameof(ShowRemoteEndpoint));
+        OnPropertyChanged(nameof(ShowLocalPort));
+    }
+
     private void StartTcpClient()
     {
         tcpClient = new AsyncTCPClient(WriteInfoLog);
-        tcpClient.ReceiveAction = data => AppendLog($"[Recv] {FormatBytes(data, SocketHexShow)}");
-        tcpClient.OnConnected = data => AppendLog($"[Conn] {Encoding.UTF8.GetString(data)}");
-        tcpClient.OnDisConnected = data => AppendLog($"[Disc] {Encoding.UTF8.GetString(data)}");
+        tcpClient.ReceiveAction = data => ShowSocketData(data, send: false, SocketHexShow);
+        tcpClient.SendAction = data => ShowSocketData(data, send: true, SocketHexSend);
+        tcpClient.OnConnected = data => AppendLog($"[SYS] {Encoding.UTF8.GetString(data)}");
+        tcpClient.OnDisConnected = data => AppendLog($"[SYS] {Encoding.UTF8.GetString(data)}");
 
         if (!tcpClient.InitClient(IPAddress.Parse(SocketRemoteHost), SocketRemotePort))
         {
@@ -247,9 +222,10 @@ public partial class NetToolPageVM : BasePageVM
     private void StartTcpServer()
     {
         tcpServer = new AsyncTCPServer(WriteInfoLog);
-        tcpServer.ReceiveAction = (_, data) => AppendLog($"[Recv] {FormatBytes(data, SocketHexShow)}");
-        tcpServer.OnConnected = data => AppendLog($"[Conn] {Encoding.UTF8.GetString(data)}");
-        tcpServer.OnDisConnected = data => AppendLog($"[Disc] {Encoding.UTF8.GetString(data)}");
+        tcpServer.ReceiveAction = (_, data) => ShowSocketData(data, send: false, SocketHexShow);
+        tcpServer.SendAction = data => ShowSocketData(data, send: true, SocketHexSend);
+        tcpServer.OnConnected = data => AppendLog($"[SYS] {Encoding.UTF8.GetString(data)}");
+        tcpServer.OnDisConnected = data => AppendLog($"[SYS] {Encoding.UTF8.GetString(data)}");
 
         if (!tcpServer.InitAsServer(IPAddress.Any, LocalPort))
         {
@@ -260,9 +236,10 @@ public partial class NetToolPageVM : BasePageVM
     private void StartUdp()
     {
         udpClient = new AsyncUDPClient(WriteInfoLog);
-        udpClient.ReceiveAction = (remote, data) => AppendLog($"[Recv {remote}] {FormatBytes(data, SocketHexShow)}");
-        udpClient.OnConnected = data => AppendLog($"[Conn] {Encoding.UTF8.GetString(data)}");
-        udpClient.OnDisConnected = _ => AppendLog("[Disc] UDP Closed");
+        udpClient.ReceiveAction = (remote, data) => ShowSocketData(data, send: false, SocketHexShow, remote);
+        udpClient.SendAction = data => ShowSocketData(data, send: true, SocketHexSend);
+        udpClient.OnConnected = data => AppendLog($"[SYS] {Encoding.UTF8.GetString(data)}");
+        udpClient.OnDisConnected = data => AppendLog($"[SYS] {Encoding.UTF8.GetString(data)}");
 
         if (!udpClient.InitClient(IPAddress.Any, LocalPort))
         {
@@ -290,8 +267,16 @@ public partial class NetToolPageVM : BasePageVM
         return Encoding.UTF8.GetString(data);
     }
 
+    private void ShowSocketData(byte[] data, bool send, bool hexMode, string? remote = null)
+    {
+        var prefix = send ? " << " : " >> ";
+        var remotePart = string.IsNullOrWhiteSpace(remote) ? string.Empty : $"[{remote}] ";
+        AppendLog($"{remotePart}{prefix}{FormatBytes(data, hexMode)}");
+    }
+
     private void AppendLog(string line)
     {
+        WriteInfoLog(line);
         Dispatcher.UIThread.Post(() =>
         {
             LogDocument.Insert(LogDocument.TextLength, $"{DateTime.Now:HH:mm:ss.fff} {line}{Environment.NewLine}");

--- a/One.Toolbox/Views/NetTool/NetToolPage.axaml
+++ b/One.Toolbox/Views/NetTool/NetToolPage.axaml
@@ -3,7 +3,9 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:AvaloniaEdit="clr-namespace:AvaloniaEdit;assembly=AvaloniaEdit"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:i="using:Avalonia.Xaml.Interactivity"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:local="clr-namespace:One.Toolbox.Behaviors"
              xmlns:vm="using:One.Toolbox.ViewModels.NetTool"
              d:DesignHeight="450"
              d:DesignWidth="900"
@@ -24,49 +26,48 @@
             </Grid>
         </TabItem>
 
-        <TabItem Header="TCP/UDP测试">
-            <StackPanel Spacing="8">
-                <Grid ColumnDefinitions="Auto,160,Auto,100,Auto,100,*" ColumnSpacing="8">
-                    <TextBlock VerticalAlignment="Center" Text="目标IP" />
-                    <TextBox Grid.Column="1" Text="{Binding TargetHost}" />
-                    <TextBlock Grid.Column="2" VerticalAlignment="Center" Text="目标端口" />
-                    <TextBox Grid.Column="3" Text="{Binding TargetPort}" />
-                    <TextBlock Grid.Column="4" VerticalAlignment="Center" Text="本地端口" />
-                    <TextBox Grid.Column="5" Text="{Binding LocalPort}" />
-                </Grid>
-                <StackPanel Orientation="Horizontal" Spacing="8">
-                    <Button Command="{Binding RunTcpTestCommand}" Content="TCP连接测试" />
-                    <Button Command="{Binding RunUdpTestCommand}" Content="UDP发送测试" />
-                </StackPanel>
-                <TextBlock Foreground="DarkCyan" Text="{Binding TestResult}" TextWrapping="Wrap" />
-            </StackPanel>
-        </TabItem>
-
         <TabItem Header="Socket调试">
-            <Grid RowDefinitions="Auto,Auto,*,Auto" RowSpacing="8">
-                <Grid ColumnDefinitions="Auto,130,Auto,160,Auto,100,Auto,100,*" ColumnSpacing="8">
-                    <TextBlock VerticalAlignment="Center" Text="模式" />
-                    <ComboBox Grid.Column="1" ItemsSource="{Binding SocketModes}" SelectedItem="{Binding SocketMode}" />
-                    <TextBlock Grid.Column="2" VerticalAlignment="Center" Text="远端IP" />
-                    <TextBox Grid.Column="3" Text="{Binding SocketRemoteHost}" />
-                    <TextBlock Grid.Column="4" VerticalAlignment="Center" Text="远端端口" />
-                    <TextBox Grid.Column="5" Text="{Binding SocketRemotePort}" />
-                    <TextBlock Grid.Column="6" VerticalAlignment="Center" Text="本地端口" />
-                    <TextBox Grid.Column="7" Text="{Binding LocalPort}" />
-                </Grid>
+            <Grid RowDefinitions="Auto,*,Auto" RowSpacing="8">
+                <Border Padding="8" Background="{DynamicResource SystemControlBackgroundChromeLowBrush}" BorderBrush="Gray" BorderThickness="1">
+                    <Grid RowDefinitions="Auto,Auto" RowSpacing="8">
+                        <Grid ColumnDefinitions="Auto,130,Auto,160,Auto,100,*" ColumnSpacing="8">
+                            <TextBlock VerticalAlignment="Center" Text="模式" />
+                            <ComboBox Grid.Column="1" ItemsSource="{Binding SocketModes}" SelectedItem="{Binding SocketMode}" />
 
-                <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="8">
-                    <Button Command="{Binding StartSocketCommand}" Content="启动" IsEnabled="{Binding !SocketStarted}" />
-                    <Button Command="{Binding StopSocketCommand}" Content="停止" IsEnabled="{Binding SocketStarted}" />
-                    <CheckBox Content="Hex发送" IsChecked="{Binding SocketHexSend}" />
-                    <CheckBox Content="Hex显示" IsChecked="{Binding SocketHexShow}" />
-                    <Button Command="{Binding ClearLogCommand}" Content="清空日志" />
-                </StackPanel>
+                            <TextBlock Grid.Column="2" VerticalAlignment="Center" IsVisible="{Binding ShowRemoteEndpoint}" Text="远端IP" />
+                            <TextBox Grid.Column="3" IsVisible="{Binding ShowRemoteEndpoint}" Text="{Binding SocketRemoteHost}" />
 
-                <AvaloniaEdit:TextEditor Grid.Row="2" Document="{Binding LogDocument}" FontFamily="Cascadia Code,Consolas,Menlo,Monospace" ShowLineNumbers="True" />
+                            <TextBlock Grid.Column="4" VerticalAlignment="Center" IsVisible="{Binding ShowRemoteEndpoint}" Text="远端端口" />
+                            <TextBox Grid.Column="5" IsVisible="{Binding ShowRemoteEndpoint}" Text="{Binding SocketRemotePort}" />
 
-                <Grid Grid.Row="3" ColumnDefinitions="*,Auto" ColumnSpacing="8">
-                    <TextBox AcceptsReturn="True" MinHeight="60" Text="{Binding SocketSendText}" TextWrapping="Wrap" />
+                            <StackPanel Grid.Column="6" Orientation="Horizontal" Spacing="6" IsVisible="{Binding ShowLocalPort}">
+                                <TextBlock VerticalAlignment="Center" Text="本地端口" />
+                                <TextBox Width="100" Text="{Binding LocalPort}" />
+                            </StackPanel>
+                        </Grid>
+
+                        <Grid Grid.Row="1" ColumnDefinitions="Auto,Auto,Auto,Auto,Auto,*" ColumnSpacing="8">
+                            <Button Command="{Binding StartSocketCommand}" Content="启动" IsEnabled="{Binding !SocketStarted}" />
+                            <Button Grid.Column="1" Command="{Binding StopSocketCommand}" Content="停止" IsEnabled="{Binding SocketStarted}" />
+                            <CheckBox Grid.Column="2" HorizontalAlignment="Center" VerticalAlignment="Center" Content="Hex发送" IsChecked="{Binding SocketHexSend}" />
+                            <CheckBox Grid.Column="3" HorizontalAlignment="Center" VerticalAlignment="Center" Content="Hex显示" IsChecked="{Binding SocketHexShow}" />
+                            <Button Grid.Column="4" Command="{Binding ClearLogCommand}" Content="清空日志" />
+                        </Grid>
+                    </Grid>
+                </Border>
+
+                <AvaloniaEdit:TextEditor Grid.Row="1"
+                                         Document="{Binding LogDocument}"
+                                         FontFamily="Cascadia Code,Consolas,Menlo,Monospace"
+                                         ShowLineNumbers="True"
+                                         WordWrap="True">
+                    <i:Interaction.Behaviors>
+                        <local:AutoScrollBehavior />
+                    </i:Interaction.Behaviors>
+                </AvaloniaEdit:TextEditor>
+
+                <Grid Grid.Row="2" ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                    <TextBox AcceptsReturn="True" MinHeight="64" Text="{Binding SocketSendText}" TextWrapping="Wrap" />
                     <Button Grid.Column="1" MinWidth="90" Command="{Binding SendSocketDataCommand}" Content="发送" />
                 </Grid>
             </Grid>


### PR DESCRIPTION
### Motivation
- 统一 `Socket调试` 与串口工具的日志展示与交互布局，减少功能重复并提升一致性与可用性。
- 保证日志与真实网络事件一致性，避免“发送后立即打印”与底层发送状态脱节的问题。
- 增强底层网络 helper 的健壮性，避免空引用、异常传播与不必要的分段发送逻辑引发运行时错误。

### Description
- 界面与交互调整：移除原有 `TCP/UDP测试` 页签，重构 `NetTool` 的 `Socket调试` 布局（日志区上置、发送区下置、控件统一排列、复选框居中），并在 XAML 中根据模式动态显示参数（新增 VM 布尔属性 `IsTcpClientMode`、`IsTcpServerMode`、`IsUdpMode`、`ShowRemoteEndpoint`、`ShowLocalPort`）。
- 日志与事件处理：将发送日志由“发送后立即打印”改为订阅底层回调（使用 `ReceiveAction` / `SendAction` / `OnConnected` / `OnDisConnected`），并统一日志前缀与格式（`[SYS]` / `[ERR]`、时间戳 `HH:mm:ss.fff`、方向标记 `<< / >>`），新增 `ShowSocketData` 与在 `AppendLog` 中复用 `WriteInfoLog`。
- NetHelpers 加固：在 `AsyncTCPClient` 中加入连接结果校验、对 `socket` 的 null 与已连接检查、接收 0 字节时退出循环与更安全的释放逻辑；在 `AsyncUDPClient` 中将发送改为一次性 datagram 调用、补充 `udpClient` 空值保护与更清晰断开信息；在 `AsyncTCPServer` 中修复 `throw ex` 为 `throw`，并在释放时逐一关闭并通知已连接客户端。
- 其它实现细节：更新 `One.Toolbox/Views/NetTool/NetToolPage.axaml`、`One.Toolbox/ViewModels/NetTool/NetToolPageVM.cs`、`One.Base/Helpers/NetHelpers/{AsyncTCPClient,AsyncTCPServer,AsyncUDPClient}.cs` 以实现上述变更并统一日志/布局行为。

### Testing
- 尝试运行 `dotnet build Avalonia.One.sln` 进行编译验证，但环境缺少 `.NET SDK`，命令返回 `dotnet: command not found`，因此无法完成编译／运行测试（失败）。
- 通过代码搜索与差异检查（`rg`/`git diff`/file listings）验证了 API 绑定、回调订阅与 XAML 数据绑定已按预期修改（成功）。
- 没有新增单元测试；建议在具备 .NET SDK 的环境下执行 `dotnet build` 与手工功能测试（启动 TCP/UDP client/server，验证 `SendAction`/`ReceiveAction` 日志行为 和 UI 上的参数显示）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21c15bb7c8328857b35f827505ca8)