### PR TITLE
DiffViewer: icon toolbar, async drag-drop loading, and SourceGit-style red/green colors

### DIFF
--- a/One.Toolbox/ViewModels/DiffViewer/DiffBackgroundRenderer.cs
+++ b/One.Toolbox/ViewModels/DiffViewer/DiffBackgroundRenderer.cs
@@ -9,10 +9,9 @@ public class DiffBackgroundRenderer : IBackgroundRenderer
 {
     private readonly Dictionary<int, DiffType> _lineTypes;
 
-    // 颜色参考常见 Git 工具：新增=绿，删除=红，修改=黄。
+    // 颜色参考 SourceGit：新增=绿，删除=红。
     private static readonly IBrush AddedBrush = new SolidColorBrush(Color.Parse("#4A2E7D32"));
     private static readonly IBrush RemovedBrush = new SolidColorBrush(Color.Parse("#4AA94442"));
-    private static readonly IBrush ModifiedBrush = new SolidColorBrush(Color.Parse("#4A9A8F33"));
 
     public DiffBackgroundRenderer(IEnumerable<DiffLine> lines)
     {
@@ -48,7 +47,6 @@ public class DiffBackgroundRenderer : IBackgroundRenderer
             {
                 DiffType.Added => AddedBrush,
                 DiffType.Removed => RemovedBrush,
-                DiffType.Modified => ModifiedBrush,
                 _ => null
             };
 

--- a/One.Toolbox/ViewModels/DiffViewer/DiffViewerPageVM.cs
+++ b/One.Toolbox/ViewModels/DiffViewer/DiffViewerPageVM.cs
@@ -12,6 +12,7 @@ public partial class DiffViewerPageVM : BasePageVM
     }
 
     private readonly List<int> _anchors = new();
+    private int _refreshVersion;
 
     public Action<DiffResult>? OnDiffUpdated;
     public Action<int>? OnNavigateToDiffLine;
@@ -54,7 +55,7 @@ public partial class DiffViewerPageVM : BasePageVM
     }
 
     [RelayCommand]
-    private void DropLeft(object? obj)
+    private async Task DropLeft(object? obj)
     {
         var path = GetFirstFilePath(obj);
         if (string.IsNullOrWhiteSpace(path))
@@ -63,12 +64,12 @@ public partial class DiffViewerPageVM : BasePageVM
         }
 
         LeftFilePath = path;
-        LeftContent = ReadAllText(path);
-        RefreshDiff();
+        LeftContent = await ReadAllTextAsync(path);
+        await RefreshDiffAsync();
     }
 
     [RelayCommand]
-    private void DropRight(object? obj)
+    private async Task DropRight(object? obj)
     {
         var path = GetFirstFilePath(obj);
         if (string.IsNullOrWhiteSpace(path))
@@ -77,8 +78,8 @@ public partial class DiffViewerPageVM : BasePageVM
         }
 
         RightFilePath = path;
-        RightContent = ReadAllText(path);
-        RefreshDiff();
+        RightContent = await ReadAllTextAsync(path);
+        await RefreshDiffAsync();
     }
 
     /// <summary>
@@ -152,11 +153,11 @@ public partial class DiffViewerPageVM : BasePageVM
         return uri.IsFile ? uri.LocalPath : uri.ToString();
     }
 
-    private static string ReadAllText(string path)
+    private static async Task<string> ReadAllTextAsync(string path)
     {
         try
         {
-            return File.ReadAllText(path);
+            return await File.ReadAllTextAsync(path);
         }
         catch
         {
@@ -167,14 +168,26 @@ public partial class DiffViewerPageVM : BasePageVM
     /// <summary>
     /// 刷新左右文件差异，并同步导航锚点。
     /// </summary>
-    private void RefreshDiff()
+    private async Task RefreshDiffAsync()
     {
-        var leftLines = NormalizeLines(LeftContent);
-        var rightLines = NormalizeLines(RightContent);
+        var leftContentSnapshot = LeftContent;
+        var rightContentSnapshot = RightContent;
+        var refreshVersion = Interlocked.Increment(ref _refreshVersion);
 
-        var result = BuildDiffResult(leftLines, rightLines);
+        var (leftLinesCount, rightLinesCount, result) = await Task.Run(() =>
+        {
+            var leftLines = NormalizeLines(leftContentSnapshot);
+            var rightLines = NormalizeLines(rightContentSnapshot);
+            var diffResult = BuildDiffResult(leftLines, rightLines);
+            return (leftLines.Count, rightLines.Count, diffResult);
+        });
 
-        TotalLineCount = Math.Max(leftLines.Count, rightLines.Count);
+        if (refreshVersion != _refreshVersion)
+        {
+            return;
+        }
+
+        TotalLineCount = Math.Max(leftLinesCount, rightLinesCount);
         ChangedLineCount = result.ChangedRows;
 
         _anchors.Clear();
@@ -244,8 +257,9 @@ public partial class DiffViewerPageVM : BasePageVM
             var modifiedCount = Math.Min(removeLines.Count, addLines.Count);
             for (var i = 0; i < modifiedCount; i++)
             {
-                result.LeftChanges.Add(new DiffLine { LineNumber = removeLines[i], Type = DiffType.Modified });
-                result.RightChanges.Add(new DiffLine { LineNumber = addLines[i], Type = DiffType.Modified });
+                // 与 SourceGit 一致：左侧修改行按删除（红色）显示，右侧按新增（绿色）显示。
+                result.LeftChanges.Add(new DiffLine { LineNumber = removeLines[i], Type = DiffType.Removed });
+                result.RightChanges.Add(new DiffLine { LineNumber = addLines[i], Type = DiffType.Added });
             }
 
             for (var i = modifiedCount; i < removeLines.Count; i++)

--- a/One.Toolbox/Views/DiffViewer/DiffViewerPage.axaml
+++ b/One.Toolbox/Views/DiffViewer/DiffViewerPage.axaml
@@ -11,6 +11,18 @@
              x:CompileBindings="False"
              x:DataType="vm:DiffViewerPageVM"
              mc:Ignorable="d">
+    <UserControl.Styles>
+        <Style Selector="Button.diff-toolbar, ToggleButton.diff-toolbar">
+            <Setter Property="MinWidth" Value="30" />
+            <Setter Property="Height" Value="30" />
+            <Setter Property="Padding" Value="0" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="CornerRadius" Value="4" />
+            <Setter Property="HorizontalContentAlignment" Value="Center" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+        </Style>
+    </UserControl.Styles>
+
     <Design.DataContext>
         <vm:DiffViewerPageVM />
     </Design.DataContext>
@@ -18,12 +30,37 @@
     <Grid RowDefinitions="Auto,Auto,*" RowSpacing="8">
         <Border Padding="8" Background="#12000000" CornerRadius="6">
             <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-                <ToggleButton Content="同步滚动" IsChecked="{Binding IsSyncScrollEnabled}" />
-                <Separator Width="8" Opacity="0" />
-                <Button Content="首个差异" Command="{Binding FirstDiffCommand}" />
-                <Button Content="上一个" Command="{Binding PreviousDiffCommand}" />
-                <Button Content="下一个" Command="{Binding NextDiffCommand}" />
-                <Button Content="最后一个" Command="{Binding LastDiffCommand}" />
+                <ToggleButton Classes="diff-toolbar"
+                              IsChecked="{Binding IsSyncScrollEnabled}"
+                              ToolTip.Tip="同步滚动">
+                    <PathIcon Width="14" Height="14"
+                              Data="M8.75 8.75A2.25 2.25 0 0 1 11 6.5h3.25a2.25 2.25 0 1 1 0 4.5H11A2.25 2.25 0 0 1 8.75 8.75Zm2.25-.75a.75.75 0 0 0 0 1.5h3.25a.75.75 0 0 0 0-1.5H11ZM4.75 13A2.25 2.25 0 1 0 4.75 17.5H8a2.25 2.25 0 1 0 0-4.5H4.75Zm0 1.5a.75.75 0 0 0 0 1.5H8a.75.75 0 0 0 0-1.5H4.75ZM6 9.5c0-1.66 1.34-3 3-3h2.5v1.5H9a1.5 1.5 0 0 0 0 3h2.5v1.5H9c-1.66 0-3-1.34-3-3Zm6.5 2h2.5a1.5 1.5 0 1 1 0 3h-2.5V16H15a3 3 0 1 0 0-6h-2.5v1.5Z" />
+                </ToggleButton>
+                <Separator Width="4" Opacity="0" />
+                <Button Classes="diff-toolbar"
+                        Command="{Binding FirstDiffCommand}"
+                        ToolTip.Tip="首个差异">
+                    <PathIcon Width="14" Height="14"
+                              Data="M5 4h1.5v16H5zM8.5 12 17 5v14z" />
+                </Button>
+                <Button Classes="diff-toolbar"
+                        Command="{Binding PreviousDiffCommand}"
+                        ToolTip.Tip="上一个差异">
+                    <PathIcon Width="14" Height="14"
+                              Data="M15.5 5 7 12l8.5 7V5z" />
+                </Button>
+                <Button Classes="diff-toolbar"
+                        Command="{Binding NextDiffCommand}"
+                        ToolTip.Tip="下一个差异">
+                    <PathIcon Width="14" Height="14"
+                              Data="M8.5 5 17 12l-8.5 7V5z" />
+                </Button>
+                <Button Classes="diff-toolbar"
+                        Command="{Binding LastDiffCommand}"
+                        ToolTip.Tip="最后一个差异">
+                    <PathIcon Width="14" Height="14"
+                              Data="M17.5 4H19v16h-1.5zM15 12 6.5 5v14z" />
+                </Button>
             </StackPanel>
         </Border>
 


### PR DESCRIPTION
### Motivation
- Improve DiffViewer toolbar UX by replacing text buttons with compact icon buttons and a consistent toolbar style matching SourceGit.
- Prevent the UI from freezing when users drag large files into the editors by making file loading and diff computation asynchronous.
- Align diff coloring with SourceGit semantics so removed lines show red and added lines show green instead of using a yellow modified background.

### Description
- Replaced the top toolbar in `One.Toolbox/Views/DiffViewer/DiffViewerPage.axaml` with icon `Button`/`ToggleButton` (`PathIcon`) and added a `diff-toolbar` style for compact, consistent visuals.
- Converted `DropLeft` and `DropRight` to asynchronous handlers in `One.Toolbox/ViewModels/DiffViewer/DiffViewerPageVM.cs` using `ReadAllTextAsync` and changed the refresh workflow to `RefreshDiffAsync` which runs diff computation on a background `Task.Run` to avoid blocking the UI.
- Added a `_refreshVersion` counter and used `Interlocked.Increment` to prevent stale background results from overwriting newer state when multiple refreshes race.
- Modified `BuildDiffResult` so paired modifications are represented as left-side `Removed` and right-side `Added` (SourceGit style), and removed the yellow `Modified` background path.
- Updated `One.Toolbox/ViewModels/DiffViewer/DiffBackgroundRenderer.cs` to drop the yellow `ModifiedBrush` and render only the red `Removed` and green `Added` brushes.

### Testing
- Attempted to run `dotnet build One.Toolbox/One.Toolbox.csproj -v minimal`, but `dotnet` is not available in this environment so the build could not be executed.
- No other automated tests were executed in this environment; changes were validated by static inspection and local edits only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba127e85a883289c0d3e0277b25a9c)