### PR TITLE
Add Todo page: View, ViewModel, and registration in main navigation

### DIFF
--- a/One.Toolbox/App.axaml.cs
+++ b/One.Toolbox/App.axaml.cs
@@ -19,6 +19,7 @@ using One.Toolbox.ViewModels.NetTool;
 using One.Toolbox.ViewModels.QRCode;
 using One.Toolbox.ViewModels.RegularTester;
 using One.Toolbox.ViewModels.Serialport;
+using One.Toolbox.ViewModels.Todo;
 using One.Toolbox.Views;
 
 using System.Globalization;
@@ -83,6 +84,7 @@ public partial class App : Application
         services.AddSingleton<DiffViewerPageVM>();
         services.AddSingleton<One.Toolbox.ViewModels.Setting.SettingsPageVM>();
         services.AddSingleton<One.Toolbox.ViewModels.Note.NotePageVM>();
+        services.AddSingleton<TodoPageVM>();
         services.AddSingleton<One.Toolbox.ViewModels.Setting.CloudSettingsVM>();
         services.AddSingleton<One.Toolbox.ViewModels.BingImage.BingImagePageVM>();
         services.AddSingleton<QRCodePageVM>();

--- a/One.Toolbox/ViewModels/MainWindow/MainViewVM.cs
+++ b/One.Toolbox/ViewModels/MainWindow/MainViewVM.cs
@@ -16,6 +16,7 @@ using One.Toolbox.ViewModels.RegularTester;
 using One.Toolbox.ViewModels.Serialport;
 using One.Toolbox.ViewModels.Setting;
 using One.Toolbox.ViewModels.UnixTimeConverter;
+using One.Toolbox.ViewModels.Todo;
 using One.Toolbox.Views;
 using One.Toolbox.Views.BingImage;
 using One.Toolbox.Views.Dashboard;
@@ -27,6 +28,7 @@ using One.Toolbox.Views.QRCode;
 using One.Toolbox.Views.RegularTester;
 using One.Toolbox.Views.Settings;
 using One.Toolbox.Views.UnixTimeConverter;
+using One.Toolbox.Views.Todo;
 
 using System.Collections.ObjectModel;
 using One.Toolbox.Views.IconBoard;
@@ -125,6 +127,12 @@ public partial class MainViewVM : BaseVM
                 Header = "Notes",
                 Icon = ResourceHelper.FindObjectResource("notepad_regular"),
                 Content = new NotePage() { DataContext = App.Current!.Services.GetService<NotePageVM>() },
+            },
+            new()
+            {
+                Header = "Todo",
+                Icon = ResourceHelper.FindObjectResource("notepad_regular"),
+                Content = new TodoPage() { DataContext = App.Current!.Services.GetService<TodoPageVM>() },
             },
             new()
             {

--- a/One.Toolbox/ViewModels/Todo/TodoPageVM.cs
+++ b/One.Toolbox/ViewModels/Todo/TodoPageVM.cs
@@ -1,0 +1,282 @@
+﻿using CommunityToolkit.Mvvm.Messaging;
+
+using One.Toolbox.Helpers;
+using One.Toolbox.Messenger;
+using One.Toolbox.ViewModels.Base;
+
+using System.Collections.ObjectModel;
+using System.Text.Json;
+
+namespace One.Toolbox.ViewModels.Todo;
+
+public partial class TodoPageVM : BasePageVM
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    private readonly string _dataFilePath = Path.Combine(PathHelper.dataPath, "todo-checklist.json");
+
+    public ObservableCollection<TodoDayVM> Days { get; set; } = [];
+
+    [ObservableProperty]
+    private TodoDayVM? selectedDay;
+
+    [ObservableProperty]
+    private string newTodoTitle = string.Empty;
+
+    [ObservableProperty]
+    private string progressText = "0%";
+
+    [ObservableProperty]
+    private double progressValue;
+
+    public TodoPageVM()
+    {
+        WeakReferenceMessenger.Default.Register<CloseMessage>(this, (_, _) => SaveSetting());
+
+        InitData();
+    }
+
+    public override void UpdateTitle()
+    {
+        Title = "Todo";
+    }
+
+    private void InitData()
+    {
+        LoadSetting();
+        SelectedDay = EnsureToday();
+        UpdateProgress();
+    }
+
+    public override void OnNavigatedLeave()
+    {
+        base.OnNavigatedLeave();
+        SaveSetting();
+    }
+
+    [RelayCommand]
+    private void AddDay()
+    {
+        var date = Days.Count == 0 ? DateTime.Today : Days.Max(x => x.Date).AddDays(1);
+        var day = new TodoDayVM(date);
+        Days.Add(day);
+        SelectedDay = day;
+
+        SortDays();
+        SaveSetting();
+    }
+
+    [RelayCommand]
+    private void GoToday()
+    {
+        SelectedDay = EnsureToday();
+        UpdateProgress();
+    }
+
+    [RelayCommand]
+    private void AddTodo()
+    {
+        if (SelectedDay is null)
+        {
+            return;
+        }
+
+        var title = NewTodoTitle?.Trim();
+        if (string.IsNullOrWhiteSpace(title))
+        {
+            return;
+        }
+
+        SelectedDay.Items.Add(new TodoItemVM
+        {
+            Title = title,
+            IsDone = false,
+        });
+
+        NewTodoTitle = string.Empty;
+        UpdateProgress();
+        SaveSetting();
+    }
+
+    [RelayCommand]
+    private void DeleteTodo(TodoItemVM? item)
+    {
+        if (item is null || SelectedDay is null)
+        {
+            return;
+        }
+
+        SelectedDay.Items.Remove(item);
+        UpdateProgress();
+        SaveSetting();
+    }
+
+    [RelayCommand]
+    private void ToggleTodo(TodoItemVM? _)
+    {
+        UpdateProgress();
+        SaveSetting();
+    }
+
+    [RelayCommand]
+    private void SyncToToday()
+    {
+        if (SelectedDay is null)
+        {
+            return;
+        }
+
+        var today = EnsureToday();
+        if (today == SelectedDay)
+        {
+            return;
+        }
+
+        var existing = today.Items.Select(x => x.Title).ToHashSet();
+        foreach (var item in SelectedDay.Items.Where(x => !x.IsDone))
+        {
+            if (existing.Add(item.Title))
+            {
+                today.Items.Add(new TodoItemVM { Title = item.Title, IsDone = false });
+            }
+        }
+
+        SelectedDay = today;
+        UpdateProgress();
+        SaveSetting();
+    }
+
+    partial void OnSelectedDayChanged(TodoDayVM? value)
+    {
+        UpdateProgress();
+    }
+
+    public void SaveSetting()
+    {
+        var data = new TodoStorage
+        {
+            Days = Days.Select(x => new TodoDayStorage
+            {
+                Date = x.Date,
+                Items = x.Items.Select(i => new TodoItemStorage { Title = i.Title, IsDone = i.IsDone }).ToList(),
+            }).ToList(),
+        };
+
+        File.WriteAllText(_dataFilePath, JsonSerializer.Serialize(data, JsonOptions));
+    }
+
+    public void LoadSetting()
+    {
+        Days.Clear();
+
+        if (!File.Exists(_dataFilePath))
+        {
+            return;
+        }
+
+        var json = File.ReadAllText(_dataFilePath);
+        var storage = JsonSerializer.Deserialize<TodoStorage>(json);
+
+        if (storage?.Days is null)
+        {
+            return;
+        }
+
+        foreach (var day in storage.Days)
+        {
+            Days.Add(new TodoDayVM(day.Date)
+            {
+                Items = new ObservableCollection<TodoItemVM>(day.Items.Select(x => new TodoItemVM
+                {
+                    Title = x.Title,
+                    IsDone = x.IsDone,
+                })),
+            });
+        }
+
+        SortDays();
+    }
+
+    private TodoDayVM EnsureToday()
+    {
+        var today = Days.FirstOrDefault(x => x.Date == DateTime.Today);
+        if (today is not null)
+        {
+            return today;
+        }
+
+        today = new TodoDayVM(DateTime.Today);
+        Days.Insert(0, today);
+        SortDays();
+        return today;
+    }
+
+    private void SortDays()
+    {
+        var ordered = Days.OrderByDescending(x => x.Date).ToList();
+        Days.Clear();
+        foreach (var day in ordered)
+        {
+            Days.Add(day);
+        }
+    }
+
+    private void UpdateProgress()
+    {
+        if (SelectedDay is null || SelectedDay.Items.Count == 0)
+        {
+            ProgressValue = 0;
+            ProgressText = "0%";
+            return;
+        }
+
+        var doneCount = SelectedDay.Items.Count(x => x.IsDone);
+        var progress = doneCount * 100.0 / SelectedDay.Items.Count;
+
+        ProgressValue = progress;
+        ProgressText = $"{Math.Round(progress)}% ({doneCount}/{SelectedDay.Items.Count})";
+    }
+}
+
+public partial class TodoDayVM : ObservableObject
+{
+    public TodoDayVM(DateTime date)
+    {
+        Date = date.Date;
+    }
+
+    [ObservableProperty]
+    private DateTime date;
+
+    [ObservableProperty]
+    private ObservableCollection<TodoItemVM> items = [];
+
+    public string DateLabel => Date.ToString("MM-dd");
+    public string WeekLabel => Date.ToString("ddd");
+}
+
+public partial class TodoItemVM : ObservableObject
+{
+    [ObservableProperty]
+    private string title = string.Empty;
+
+    [ObservableProperty]
+    private bool isDone;
+}
+
+public class TodoStorage
+{
+    public List<TodoDayStorage> Days { get; set; } = [];
+}
+
+public class TodoDayStorage
+{
+    public DateTime Date { get; set; }
+    public List<TodoItemStorage> Items { get; set; } = [];
+}
+
+public class TodoItemStorage
+{
+    public string Title { get; set; } = string.Empty;
+    public bool IsDone { get; set; }
+}

--- a/One.Toolbox/Views/Todo/TodoPage.axaml
+++ b/One.Toolbox/Views/Todo/TodoPage.axaml
@@ -1,0 +1,95 @@
+<UserControl x:Class="One.Toolbox.Views.Todo.TodoPage"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:u="https://irihi.tech/ursa"
+             xmlns:vms="using:One.Toolbox.ViewModels.Todo"
+             d:DesignHeight="450"
+             d:DesignWidth="800"
+             x:DataType="vms:TodoPageVM"
+             mc:Ignorable="d">
+
+    <Design.DataContext>
+        <vms:TodoPageVM />
+    </Design.DataContext>
+
+    <Grid ColumnDefinitions="210,8,*" Margin="8">
+        <Border Grid.Column="0" Padding="6" CornerRadius="8" Background="#14000000">
+            <Grid RowDefinitions="Auto,*,Auto">
+                <u:ToolBar Grid.Row="0">
+                    <Button Command="{Binding AddDayCommand}" ToolTip.Tip="新增日期">
+                        <PathIcon Width="16" Height="16" Data="{DynamicResource note_add_regular}" />
+                    </Button>
+                    <Button Command="{Binding GoTodayCommand}" Margin="4,0,0,0" Content="今天" />
+                </u:ToolBar>
+
+                <ListBox Grid.Row="1"
+                         Margin="0,8,0,8"
+                         ItemsSource="{Binding Days}"
+                         SelectedItem="{Binding SelectedDay}">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate DataType="vms:TodoDayVM">
+                            <Border Padding="8,6">
+                                <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto">
+                                    <TextBlock Grid.RowSpan="2" Width="42" FontSize="18" FontWeight="Bold" Text="{Binding DateLabel}" />
+                                    <TextBlock Grid.Column="1" FontSize="12" Opacity="0.75" Text="{Binding WeekLabel}" />
+                                    <TextBlock Grid.Column="1" Grid.Row="1" FontSize="11" Opacity="0.6" Text="{Binding Date, StringFormat={}{0:yyyy-MM-dd}}" />
+                                </Grid>
+                            </Border>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+
+                <TextBlock Grid.Row="2" FontSize="12" Opacity="0.7" Text="左侧日期，中间待办" />
+            </Grid>
+        </Border>
+
+        <GridSplitter Grid.Column="1" Width="8" HorizontalAlignment="Stretch" />
+
+        <Border Grid.Column="2" Padding="12" CornerRadius="8" Background="#10000000">
+            <Grid RowDefinitions="Auto,Auto,Auto,*">
+                <Grid ColumnDefinitions="*,Auto,Auto" VerticalAlignment="Center">
+                    <TextBlock FontSize="24" FontWeight="SemiBold" Text="{Binding SelectedDay.Date, StringFormat={}{0:yyyy-MM-dd}}" />
+                    <TextBlock Grid.Column="1" Margin="16,0,0,0" VerticalAlignment="Center" FontSize="13" Opacity="0.75" Text="进度" />
+                    <TextBlock Grid.Column="2" Margin="8,0,0,0" VerticalAlignment="Center" FontSize="13" FontWeight="Bold" Text="{Binding ProgressText}" />
+                </Grid>
+
+                <StackPanel Grid.Row="1" Margin="0,12,0,12" Orientation="Horizontal" Spacing="8">
+                    <TextBox Width="420" Watermark="输入待办事项"
+                             Text="{Binding NewTodoTitle}" />
+                    <Button Command="{Binding AddTodoCommand}" Content="新增" />
+                    <Button Command="{Binding SyncToTodayCommand}" Content="同步到今天" />
+                </StackPanel>
+
+                <ProgressBar Grid.Row="2"
+                             Height="8"
+                             Minimum="0"
+                             Maximum="100"
+                             Value="{Binding ProgressValue}" />
+
+                <ListBox Grid.Row="3" Margin="0,12,0,0" ItemsSource="{Binding SelectedDay.Items}">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate DataType="vms:TodoItemVM">
+                            <Border Margin="0,0,0,6" Padding="8" CornerRadius="6" Background="#0F000000">
+                                <Grid ColumnDefinitions="Auto,*,Auto" VerticalAlignment="Center">
+                                    <CheckBox IsChecked="{Binding IsDone}"
+                                              Command="{Binding $parent[UserControl].DataContext.ToggleTodoCommand}"
+                                              CommandParameter="{Binding}" />
+                                    <TextBlock Grid.Column="1" Margin="8,0,8,0" VerticalAlignment="Center" Text="{Binding Title}" />
+                                    <Button Grid.Column="2"
+                                            Width="28"
+                                            Height="28"
+                                            Command="{Binding $parent[UserControl].DataContext.DeleteTodoCommand}"
+                                            CommandParameter="{Binding}">
+                                        <PathIcon Width="14" Height="14" Data="{DynamicResource delete_regular}" />
+                                    </Button>
+                                </Grid>
+                            </Border>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+            </Grid>
+        </Border>
+    </Grid>
+</UserControl>

--- a/One.Toolbox/Views/Todo/TodoPage.axaml.cs
+++ b/One.Toolbox/Views/Todo/TodoPage.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace One.Toolbox.Views.Todo;
+
+public partial class TodoPage : UserControl
+{
+    public TodoPage()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a simple Todo/checklist feature integrated into the app with per-day lists, progress tracking and persistent storage.

### Description
- Added `TodoPageVM` implementing per-day todo lists, item toggling, sync-to-today, and JSON persistence to `todo-checklist.json` under the app data path.
- Added `TodoPage.axaml` and `TodoPage.axaml.cs` view files to present day list, item list, progress bar, and controls for adding/syncing todos.
- Registered `TodoPageVM` in the service container in `App.ConfigureServices` and added the `TodoPage` entry to the main navigation in `MainViewVM` so the page appears in the app UI.
- Added necessary `using` imports and small wiring to integrate the new view and viewmodel with the existing messaging and lifecycle hooks.

### Testing
- Built the solution with `dotnet build` and the project compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba1d264c108328bc496c210fbf8c46)