### PR TITLE
fix: restore drag support on custom Windows title bar after Avalonia 12 upgrade

### DIFF
--- a/One.Control/WindowsTitleBar/WindowsTitleBar.cs
+++ b/One.Control/WindowsTitleBar/WindowsTitleBar.cs
@@ -6,6 +6,7 @@ using Avalonia.Input;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Avalonia.Reactive;
+using Avalonia.VisualTree;
 
 using One.Control.Extensions;
 
@@ -101,6 +102,7 @@ public class WindowsTitleBar : ContentControl
             minimizeButton.Click += MinimizeWindow;
             maximizeButton.Click += MaximizeWindow;
             closeButton.Click += CloseWindow;
+            titleBar.PointerPressed += TitleBarPointerPressed;
             //windowIcon.DoubleTapped += CloseWindow;
 
             SubscribeToWindowState();
@@ -136,6 +138,24 @@ public class WindowsTitleBar : ContentControl
     }
 
     #endregion MinMaxCloseEvent
+
+    private void TitleBarPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+        {
+            return;
+        }
+
+        if (e.Source is Visual sourceVisual && sourceVisual.FindAncestorOfType<Button>() is not null)
+        {
+            return;
+        }
+
+        if (TopLevel.GetTopLevel(this) is Window hostWindow)
+        {
+            hostWindow.BeginMoveDrag(e);
+        }
+    }
 
     private async void SubscribeToWindowState()
     {


### PR DESCRIPTION
### Motivation
- After upgrading to Avalonia 12 the custom title bar stopped initiating window drags via `BeginMoveDrag`, breaking expected window move behavior. 
- The fix must restore drag-on-title behavior while not interfering with title bar buttons (minimize/maximize/close).

### Description
- Wire `PART_TitleBar.PointerPressed` to a new `TitleBarPointerPressed` handler inside `OnApplyTemplate` in `One.Control/WindowsTitleBar/WindowsTitleBar.cs`. 
- Add `TitleBarPointerPressed` which verifies left-button press via `e.GetCurrentPoint(this).Properties.IsLeftButtonPressed` and calls `hostWindow.BeginMoveDrag(e)` when appropriate. 
- Ignore pointer presses that originate from title bar `Button` controls by checking `FindAncestorOfType<Button>()` and add `using Avalonia.VisualTree;` to support the ancestor lookup. 
- Changes are limited to `One.Control/WindowsTitleBar/WindowsTitleBar.cs` and only affect pointer handling for the title bar.

### Testing
- Attempted automated build with `dotnet build Avalonia.One.slnx -v minimal`, but `dotnet` is not available in the current environment so the build could not be executed (`dotnet: command not found`).
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1f0dfa2a48328b11e6b2df70ebf82)